### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tink-ab/sdk-maintainer


### PR DESCRIPTION
## Why

To take ownership of the repo

## What

Add `@tink-ab/sdk-maintainer` as owner of the repo